### PR TITLE
Feature: Add config variable to list provinces before states

### DIFF
--- a/src/Fields/StateDropdownField.php
+++ b/src/Fields/StateDropdownField.php
@@ -170,7 +170,9 @@ class StateDropdownField extends DropdownField
         }
 
         if ($globalDefaults && $includeProvinces) {
-            $states = array_merge($states, $this->getDefaultProvincesList());
+            $states = (bool)$this->config('states_first')
+                ? array_merge($states, $this->getDefaultProvincesList())
+                : array_merge($this->getDefaultProvincesList(), $states);
         }
 
         reset($states);

--- a/src/Fields/StateDropdownField.php
+++ b/src/Fields/StateDropdownField.php
@@ -170,7 +170,7 @@ class StateDropdownField extends DropdownField
         }
 
         if ($globalDefaults && $includeProvinces) {
-            $states = (bool)$this->config('states_first')
+            $states = (bool)$this->config()->get('states_first')
                 ? array_merge($states, $this->getDefaultProvincesList())
                 : array_merge($this->getDefaultProvincesList(), $states);
         }

--- a/src/Fields/StateDropdownField.php
+++ b/src/Fields/StateDropdownField.php
@@ -88,6 +88,16 @@ class StateDropdownField extends DropdownField
     /**
      * @var bool
      */
+    private static $include_provinces = true;
+
+    /**
+     * @var bool
+     */
+    private static $states_first = true;
+
+    /**
+     * @var bool
+     */
     private static $include_state_province_separator = true;
 
     /**
@@ -140,8 +150,12 @@ class StateDropdownField extends DropdownField
      * @param bool $includeProvinces
      * @return $this
      */
-    public function setStates($states = [], $includeProvinces = true)
+    public function setStates($states = [], $includeProvinces = null)
     {
+        $includeProvinces = isset($includeProvinces)
+            ? $includeProvinces
+            : $this->config()->get('include_provinces');
+
         if ($states !== (array)$states) {
             trigger_error(
                 "The \$source passed isn't an array. When passing a source it must be an array.",
@@ -176,7 +190,19 @@ class StateDropdownField extends DropdownField
      */
     protected function getDefaultStatesList()
     {
-        return $this->config()->get('default_states');
+        $states = (
+            (bool)$this->config()->get('include_state_province_separator') &&
+            (bool)!$this->config()->get('states_first')
+        )
+            ? [
+                (string)$this->config()->get('option_separator_value') => (string)$this->config()->get(
+                    'option_separator'
+                ),
+            ]
+            : [];
+        $states = array_merge($states, $this->config()->get('default_states'));
+
+        return $states;
     }
 
     /**
@@ -184,7 +210,10 @@ class StateDropdownField extends DropdownField
      */
     protected function getDefaultProvincesList()
     {
-        $provinces = ((bool)$this->config()->get('include_state_province_separator'))
+        $provinces = (
+            (bool)$this->config()->get('include_state_province_separator') &&
+            (bool)$this->config()->get('states_first')
+        )
             ? [
                 (string)$this->config()->get('option_separator_value') => (string)$this->config()->get(
                     'option_separator'

--- a/tests/StateDropdownTest.php
+++ b/tests/StateDropdownTest.php
@@ -4,6 +4,7 @@ namespace Dynamic\StateDropdownField\Tests;
 
 use Dynamic\StateDropdownField\Fields\StateDropdownField;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Config\Config;
 
 /**
  * Class StateDropdownTest
@@ -141,5 +142,140 @@ class StateDropdownTest extends SapphireTest
 
         $dropdown2 = StateDropdownField::create('TestField2', 'Test Field 2');
         $this->assertEquals(['-'], $dropdown2->getDisabledItems());
+    }
+
+    public function testConfigIncludeProvincesFalse()
+    {
+        $withoutStates = [
+            'AL' => 'Alabama',
+            'AK' => 'Alaska',
+            'AZ' => 'Arizona',
+            'AR' => 'Arkansas',
+            'CA' => 'California',
+            'CO' => 'Colorado',
+            'CT' => 'Connecticut',
+            'DE' => 'Delaware',
+            'DC' => 'District Of Columbia',
+            'FL' => 'Florida',
+            'GA' => 'Georgia',
+            'HI' => 'Hawaii',
+            'ID' => 'Idaho',
+            'IL' => 'Illinois',
+            'IN' => 'Indiana',
+            'IA' => 'Iowa',
+            'KS' => 'Kansas',
+            'KY' => 'Kentucky',
+            'LA' => 'Louisiana',
+            'ME' => 'Maine',
+            'MD' => 'Maryland',
+            'MA' => 'Massachusetts',
+            'MI' => 'Michigan',
+            'MN' => 'Minnesota',
+            'MS' => 'Mississippi',
+            'MO' => 'Missouri',
+            'MT' => 'Montana',
+            'NE' => 'Nebraska',
+            'NV' => 'Nevada',
+            'NH' => 'New Hampshire',
+            'NJ' => 'New Jersey',
+            'NM' => 'New Mexico',
+            'NY' => 'New York',
+            'NC' => 'North Carolina',
+            'ND' => 'North Dakota',
+            'OH' => 'Ohio',
+            'OK' => 'Oklahoma',
+            'OR' => 'Oregon',
+            'PA' => 'Pennsylvania',
+            'RI' => 'Rhode Island',
+            'SC' => 'South Carolina',
+            'SD' => 'South Dakota',
+            'TN' => 'Tennessee',
+            'TX' => 'Texas',
+            'UT' => 'Utah',
+            'VT' => 'Vermont',
+            'VA' => 'Virginia',
+            'WA' => 'Washington',
+            'WV' => 'West Virginia',
+            'WI' => 'Wisconsin',
+            'WY' => 'Wyoming'
+        ];
+
+        Config::modify()->set(StateDropdownField::class, 'include_provinces', false);
+
+        $dropdown = StateDropdownField::create('TestField', 'Test Field');
+        $this->assertEquals($withoutStates, $dropdown->getSource());
+    }
+
+    public function testConfigStatesFirstFalse()
+    {
+        $provinces_first = [
+            'AB' => 'Alberta',
+            'BC' => 'British Columbia',
+            'MB' => 'Manitoba',
+            'NB' => 'New Brunswick',
+            'NL' => 'Newfoundland and Labrador',
+            'NS' => 'Nova Scotia',
+            'ON' => 'Ontario',
+            'PE' => 'Prince Edward Island',
+            'QC' => 'Quebec',
+            'SK' => 'Saskatchewan',
+            '-' => '-----',
+            'AL' => 'Alabama',
+            'AK' => 'Alaska',
+            'AZ' => 'Arizona',
+            'AR' => 'Arkansas',
+            'CA' => 'California',
+            'CO' => 'Colorado',
+            'CT' => 'Connecticut',
+            'DE' => 'Delaware',
+            'DC' => 'District Of Columbia',
+            'FL' => 'Florida',
+            'GA' => 'Georgia',
+            'HI' => 'Hawaii',
+            'ID' => 'Idaho',
+            'IL' => 'Illinois',
+            'IN' => 'Indiana',
+            'IA' => 'Iowa',
+            'KS' => 'Kansas',
+            'KY' => 'Kentucky',
+            'LA' => 'Louisiana',
+            'ME' => 'Maine',
+            'MD' => 'Maryland',
+            'MA' => 'Massachusetts',
+            'MI' => 'Michigan',
+            'MN' => 'Minnesota',
+            'MS' => 'Mississippi',
+            'MO' => 'Missouri',
+            'MT' => 'Montana',
+            'NE' => 'Nebraska',
+            'NV' => 'Nevada',
+            'NH' => 'New Hampshire',
+            'NJ' => 'New Jersey',
+            'NM' => 'New Mexico',
+            'NY' => 'New York',
+            'NC' => 'North Carolina',
+            'ND' => 'North Dakota',
+            'OH' => 'Ohio',
+            'OK' => 'Oklahoma',
+            'OR' => 'Oregon',
+            'PA' => 'Pennsylvania',
+            'RI' => 'Rhode Island',
+            'SC' => 'South Carolina',
+            'SD' => 'South Dakota',
+            'TN' => 'Tennessee',
+            'TX' => 'Texas',
+            'UT' => 'Utah',
+            'VT' => 'Vermont',
+            'VA' => 'Virginia',
+            'WA' => 'Washington',
+            'WV' => 'West Virginia',
+            'WI' => 'Wisconsin',
+            'WY' => 'Wyoming',
+        ];
+
+        Config::modify()->set(StateDropdownField::class, 'states_first', false);
+
+        $dropdown = StateDropdownField::create('TestField', 'Test Field');
+        $this->assertEquals($provinces_first, $dropdown->getSource());
     }
 }


### PR DESCRIPTION
When creating forms for primarily Canadian users it makes sense to list provinces before US states, rather than after. Without this PR I can only do this by feeding the entire list into $default_states or getStates(). 

This PR allows setting `states_first: false` to invert the order. It also adds a config value for `include_provinces` as I presume in most cases a site will configure all instances of the field the same way.